### PR TITLE
Add link to related project Prepend file CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,10 @@ Asynchronously prepend data to a file, creating the file if it not yet exists. d
 
 The synchronous version of prependFile. Returns undefined.
 
+## Related
+
+* [prepend-file-cli](https://github.com/martinvd/prepend-file-cli)
+
 ## License
 
 MIT © [Hemanth.HM](http://h3manth.com)


### PR DESCRIPTION
The [CLI module](https://github.com/martinvd/prepend-file-cli) uses this project internally. It's handy when eg. using the prepend-file functionality in NPM-scripts.