### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 npm-debug.log
+.idea

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = function prependFile(path, data, options) {
     flags: 'a'
   };
 
+  // a temp file is written even if dist file does not exist. PR welcome for better implementation.
   tmp
     .file(function (err, tempFilePath, fd, cleanupCallback) {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs');
 var util = require('util');
-var tempfile = require('tempfile');
+var tmp = require('tmp');
 
 var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 
@@ -30,20 +30,6 @@ function maybeCallback(callback) {
   return typeof callback === 'function' ? callback : rethrow();
 }
 
-function cutTmp(src, dest, options, callback) {
-  fs.createReadStream(src, options)
-    .on('error', function(err) {
-      callback(err);
-    })
-    .pipe(fs.createWriteStream(dest, options))
-    .on('error', function(err) {
-      callback(err);
-    })
-    .on('finish', function() {
-      fs.unlink(src, callback);
-    });
-}
-
 module.exports = function prependFile(path, data, options) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
@@ -61,43 +47,59 @@ module.exports = function prependFile(path, data, options) {
     throw new TypeError('Bad arguments');
   }
 
-  var tmp = tempfile();
-
   var appendOptions = {
     encoding: options.encoding,
     mode: options.mode,
     flags: 'a'
   };
 
-  // a temp file is written even if dist file does not exist. PR welcome for better implementation.
-  fs.writeFile(tmp, data, options, function(err) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    fs.createReadStream(path, options)
-      .on('error', function(err) {
-        if (err.code === 'ENOENT' /*file does not exist*/) {
-          fs.writeFile(path, data, options, function(err) {
-            if (err) {
-              callback(err);
-            } else {
-              callback();
-            }
-          });
-        } else {
-          callback(err);
-        }
-      })
-      .pipe(fs.createWriteStream(tmp, appendOptions))
-      .on('error', function(err) {
+  tmp
+    .file(function (err, tempFilePath, fd, cleanupCallback) {
+      if (err) {
         callback(err);
-      })
-      .on('finish', function() {
-        cutTmp(tmp, path, options, callback);
+        return;
+      }
+
+      fs.writeFile(tempFilePath, data, options, function (err) {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        fs.createReadStream(path, options)
+          .on('error', function(err) {
+            if (err.code === 'ENOENT' /*file does not exist*/) {
+              fs.writeFile(path, data, options, function (err) {
+                if (err) {
+                  callback(err);
+                } else {
+                  callback();
+                }
+              });
+            } else {
+              callback(err);
+            }
+          })
+          .pipe(fs.createWriteStream(tempFilePath, appendOptions))
+          .on('error', function(err) {
+            callback(err);
+          })
+          .on('finish', function() {
+            fs.createReadStream(tempFilePath, options)
+              .on('error', function(err) {
+                callback(err);
+              })
+              .pipe(fs.createWriteStream(path, options))
+              .on('error', function(err) {
+                callback(err);
+              })
+              .on('finish', function() {
+                cleanupCallback();
+                callback();
+              });
+          });
       });
-  });
+    });
 };
 
 module.exports.sync = function sync(path, data, options) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "mocha": "*"
   },
   "dependencies": {
-    "tmp": "0.0.30"
+    "tmp": "0.0.31"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "mocha": "*"
   },
   "dependencies": {
-    "tempfile": "^1.1.1"
+    "tmp": "0.0.30"
   }
 }


### PR DESCRIPTION
This PR adds tested support for Windows. Before the removal of the temporary failed on Windows and thus the module wasn't usable.

I've replaced `tempfile` with `tmp` which contains Windows-compatible support for removing the temporary file. There's no breaking changes involved.

**Before**
![windows-failure](https://cloud.githubusercontent.com/assets/1725563/20484294/d2911e30-aff6-11e6-84ca-5ae914a3955e.png)

**After**
Works, content is prepended.