### PR TITLE
Prevent creation of temporary file if destination file does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.10'
+  - '4'
+  - '5'
+  - '6'
 after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/file-exists-error.js
+++ b/file-exists-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.FileExistsError = FileExistsError;
+
+function FileExistsError(message) {
+  this.message = message;
+  this.name = 'FileExistsError';
+  Error.captureStackTrace(this, FileExistsError);
+}
+
+FileExistsError.prototype = Object.create(Error.prototype);
+FileExistsError.prototype.constructor = FileExistsError;

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const fs = require('fs');
+const tmp = require('tmp');
+const FileExistsError = require('./file-exists-error').FileExistsError;
+
+module.exports.createFile = createFile;
+module.exports.createTempFile = createTempFile;
+module.exports.fileExists = fileExists;
+module.exports.maybeCallback = maybeCallback;
+module.exports.writeFileContentsToFile = writeFileContentsToFile;
+module.exports.writeToFile = writeToFile;
+
+function fileExists(path) {
+  return new Promise((resolve, reject) => {
+    fs
+      .stat(path, function (err) {
+        if (err) {
+          reject(new FileExistsError(err.message));
+        } else {
+          resolve();
+        }
+      });
+  });
+}
+
+function createFile(path, content, options) {
+  return new Promise((resolve, reject) => {
+    fs
+      .writeFile(path, content, options, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(path);
+        }
+      });
+  });
+}
+
+function createTempFile() {
+  return new Promise((resolve, reject) => {
+    tmp
+      .file((err, path, fd, cleanUpCallback) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({
+            path: path,
+            cleanUpCallback: cleanUpCallback
+          });
+        }
+      });
+  });
+}
+
+function writeToFile(path, data, options) {
+  return new Promise((resolve, reject) => {
+    fs
+      .writeFile(path, data, options, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(path);
+        }
+      });
+  });
+}
+
+function writeFileContentsToFile(source, dest, options, append) {
+  append = append || false;
+
+  const appendOptions = {
+    encoding: options.encoding,
+    mode: options.mode,
+    flags: 'a'
+  };
+
+  return new Promise((resolve, reject) => {
+    fs
+      .createReadStream(source, options)
+      .pipe(fs.createWriteStream(dest, append ? appendOptions : options))
+      .on('error', err => {
+        reject(err);
+      })
+      .on('finish', () => {
+        resolve();
+      });
+  });
+}
+
+const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
+
+function rethrow() {
+  // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and is fairly slow to generate.
+  if (DEBUG) {
+    const backtrace = new Error();
+    return function(err) {
+      if (err) {
+        backtrace.stack = err.name + ': ' + err.message +
+          backtrace.stack.substr(backtrace.name.length);
+        err = backtrace;
+        throw err;
+      }
+    };
+  }
+
+  return function(err) {
+    if (err) {
+      throw err; // Forgot a callback but don't know where? Use NODE_DEBUG=fs
+    }
+  };
+}
+
+function maybeCallback(callback) {
+  return typeof callback === 'function' ? callback : rethrow();
+}


### PR DESCRIPTION
My attempt to prevent creating a temporary file if the destination file does not exist. Instead it will directly use the content to append to create the new file.

The new flow is written using Promises. This would mean a major version bump. The main advantage of Promises here is more readable code.


**Previous flow**
1. Create a temp file
2. Write content to prepend to the temp file
3. Open a read stream of the destination file, only to fail because the file doesn't exist
4. Create the destination file

**Proposed flow**
1. Detect if the file exist
2. If not, create the file immediately using the data to prepend

**Todo**
* write tests for helper functions
* ES2015-ify all code
* v1.x -> v2.x

@hemanth / @stevemao I'm looking forward to your feedback on my approach. Thanks!