### PR TITLE
Keep the shebang intact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepend-to-js-file",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Prepend data to a file, creating it if it doesn't exist.",
   "repository": "https://github.com/GerHobbelt/node-prepend-file.git",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "prepend-file",
+  "name": "prepend-to-js-file",
   "version": "1.3.1",
   "description": "Prepend data to a file, creating it if it doesn't exist.",
-  "repository": "https://github.com/hemanth/node-prepend-file.git",
+  "repository": "https://github.com/GerHobbelt/node-prepend-file.git",
   "author": {
     "name": "Hemanth.HM",
     "email": "hemanth.hm@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepend-to-js-file",
-  "version": "1.3.2",
+  "version": "1.3.3-0",
   "description": "Prepend data to a file, creating it if it doesn't exist.",
   "repository": "https://github.com/GerHobbelt/node-prepend-file.git",
   "author": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "ava": "^3.11.0",
+    "ava": "^3.11.1",
     "coveralls": "^3.1.0",
     "nyc": "^15.1.0",
     "xo": "^0.32.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test": "xo && nyc ava"
+    "test": "xo && nyc ava",
+    "pub": "npm publish --access public"
   },
   "keywords": [
     "fs",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 # prepend-file [![Build Status][travis-image]][travis-url] [![Code Coverage][coveralls-image]][coveralls-url]
 
 > Prepend data to a file, creating it if it doesn't exist.
+> 
+> When the file (*to be prepended to*) has [a 'hash bang' a.k.a. *shebang* command](https://en.wikipedia.org/wiki/Shebang_(Unix)) at the first line, this will be kept intact.
 
 ## Install
 


### PR DESCRIPTION
Same as for the UTF8 BOM recognition, only this time for `#!xyz...` shebangs.

This was needed to fix https://github.com/silesky/prepend-header/issues/5 -- I don't know if you like to incorporate this new behaviour in your module, so I forked the repo and created another npm package: `prepend-to-js-file` by renaming this one.

Hence you might want to cherry-pick instead of executing a straight merge of this work.

Thanks!