### PR TITLE
Remove `path-exists` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ package-lock.json
 /node_modules/
 npm-debug.log
 .idea
+.temp1
+.temp2

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = async (filename, data) => {
 
   filename = path.resolve(filename);
   const temporaryFile = await tempWrite(data);
+
   try {
     await pipeline(fs.createReadStream(filename), checkStripBomTransformer, fs.createWriteStream(temporaryFile, {flags: 'a'}));
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "prepend"
   ],
   "dependencies": {
-    "path-exists": "^4.0.0",
     "temp-write": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
path-exists itself recommends not using it to check a file before using it: https://github.com/sindresorhus/path-exists

> In particular, checking if a file exists before opening it is an anti-pattern that leaves you vulnerable to race conditions: another process may remove the file between the calls to fs.exists() and fs.open(). Just open the file and handle the error when it's not there.

Also, there is a very minor performance benefit since I predict most users aren't prepending to non-existent files. In those cases, we save an extra syscall :)